### PR TITLE
Changed footer heading to h4

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -135,6 +135,3 @@ p {
     text-align: center;
 }
 
-.footer h2 {
-    font-size: 20px;
-}


### PR DESCRIPTION
Changed footer heading to h4 to ensure headings in html are used sequentially to increase accessibility of website. 